### PR TITLE
添加任务状态以及清理retry count

### DIFF
--- a/src/agent/agent_internal_infos.h
+++ b/src/agent/agent_internal_infos.h
@@ -41,6 +41,8 @@ struct TaskInfo {
     Initd_Stub* initd_stub;
     CGroupResourceCollector* resource_collector; 
 
+    int64_t retry_refresh_time;
+
     std::string ToString() {
         std::string pb_str;
         std::string str_format;     
@@ -100,7 +102,8 @@ struct TaskInfo {
           stop_timeout_point(0),
           initd_check_failed(0),
           initd_stub(NULL),
-          resource_collector(NULL) {
+          resource_collector(NULL),
+          retry_refresh_time(0L) {
     }
 
     void CopyFrom(const TaskInfo& task) {
@@ -122,6 +125,7 @@ struct TaskInfo {
         initd_check_failed = task.initd_check_failed;
         initd_stub = task.initd_stub;
         resource_collector = task.resource_collector;
+        retry_refresh_time = task.retry_refresh_time;
     }
 
     TaskInfo& operator=(const TaskInfo& task) {

--- a/src/agent/pod_manager.cc
+++ b/src/agent/pod_manager.cc
@@ -346,6 +346,9 @@ int PodManager::CheckPod(const std::string& pod_id) {
         case kTaskFinish :
         pod_info.pod_status.set_state(kPodFinish);
         break;
+        case kTaskRestart : 
+        pod_info.pod_status.set_state(kPodRestart);
+        break;
     }
 
     for (size_t i = 0; i < to_del_task.size(); i++) {

--- a/src/agent/task_manager.cc
+++ b/src/agent/task_manager.cc
@@ -1066,6 +1066,7 @@ void TaskManager::RefreshRetryTimes(TaskInfo* task_info) {
     if (now_time - task_info->retry_refresh_time 
                     > FLAGS_agent_task_refresh_interval) {
         task_info->fail_retry_times = 0; 
+        task_info->retry_refresh_time = now_time;
     }
     return;
 }

--- a/src/agent/task_manager.h
+++ b/src/agent/task_manager.h
@@ -43,6 +43,8 @@ protected:
     int CleanProcess(TaskInfo* task_info);
     int CleanCpuScheduler(TaskInfo* task_info);
 
+    // simple strategy to clear retry_times
+    void RefreshRetryTimes(TaskInfo* task_info);
     void SetResourceUsage(TaskInfo* task_info);
     // task stage run
     int DeployTask(TaskInfo* task_info);

--- a/src/flags.cc
+++ b/src/flags.cc
@@ -69,6 +69,7 @@ DEFINE_int32(cpu_scheduler_guarantee, 1500, "agent cpu scheduler guarantee");
 DEFINE_int32(cpu_scheduler_dec, 500, "agent cpu scheduler dec");
 DEFINE_bool(cpu_scheduler_switch, false, "agent cpu scheduler switch");
 DEFINE_int32(cpu_scheduler_start_frozen_time, 20, "start forzen time, unit second");
+DEFINE_int64(agent_task_refresh_interval, 3600 * 12, "agent task refresh retry times");
 
 
 // gce

--- a/src/flags.cc
+++ b/src/flags.cc
@@ -70,7 +70,7 @@ DEFINE_int32(cpu_scheduler_dec, 500, "agent cpu scheduler dec");
 DEFINE_bool(cpu_scheduler_switch, false, "agent cpu scheduler switch");
 DEFINE_int32(cpu_scheduler_start_frozen_time, 20, "start forzen time, unit second");
 DEFINE_int64(agent_task_refresh_interval, 3600 * 12, "agent task refresh retry times");
-
+DEFINE_int64(agent_task_delay_check_interval, 50, "agent task deplay check interval unit ms");
 
 // gce
 DEFINE_string(gce_cgroup_root, "/cgroups/", "Cgroup root mount path");

--- a/src/master/job_manager.cc
+++ b/src/master/job_manager.cc
@@ -37,6 +37,7 @@ JobManager::JobManager()
     state_to_stage_[kPodRunning] = kStageRunning;
     state_to_stage_[kPodTerminate] = kStageDeath;
     state_to_stage_[kPodError] = kStageDeath;
+    state_to_stage_[kPodRestart] = kStageRunning;
     BuildPodFsm();
     nexus_ = new ::galaxy::ins::sdk::InsSDK(FLAGS_nexus_servers);
 }
@@ -1065,7 +1066,8 @@ void JobManager::GetJobsOverview(JobOverviewList* jobs_overview) {
         for (; pod_it != pods.end(); ++pod_it) {
             // const PodId& podid = pod_it->first;
             const PodStatus* pod = pod_it->second;
-            if (pod->state() == kPodRunning) {
+            if (pod->state() == kPodRunning
+                    || pod->state() == kPodRestart) {
                 running_num++;
                 MasterUtil::AddResource(pod->resource_used(), overview->mutable_resource_used());
             } else if(pod->state() == kPodPending) {

--- a/src/proto/galaxy.proto
+++ b/src/proto/galaxy.proto
@@ -27,6 +27,7 @@ enum PodState {
     kPodSuspend = 4;
     kPodFinish = 5;
     kPodError = 6;
+    kPodRestart = 7;
 }
 
 enum PodStage {
@@ -44,6 +45,7 @@ enum TaskState {
     kTaskSuspend = 4;
     kTaskFinish = 5;
     kTaskError = 6;
+    kTaskRestart = 7;
 }
 
 


### PR DESCRIPTION
1. 添加restart状态，对用户可见重启（但由于agent检测进程运行状态来判断，因此该状态只表示进程存在重启过）
2. 定期清理retry_count， 降低不必要的迁移