### PR TITLE
galaxy killer

### DIFF
--- a/src/agent/agent_internal_infos.h
+++ b/src/agent/agent_internal_infos.h
@@ -43,7 +43,6 @@ struct TaskInfo {
     std::string gc_dir;
     Initd_Stub* initd_stub;
     CGroupResourceCollector* resource_collector; 
-    bool delay_restarted;
     std::string ToString() {
         std::string pb_str;
         std::string str_format;     
@@ -103,8 +102,7 @@ struct TaskInfo {
           stop_timeout_point(0),
           initd_check_failed(0),
           initd_stub(NULL),
-          resource_collector(NULL),
-          delay_restarted(false){
+          resource_collector(NULL){
     }
 
     void CopyFrom(const TaskInfo& task) {

--- a/src/agent/cgroups.cc
+++ b/src/agent/cgroups.cc
@@ -17,7 +17,6 @@
 namespace baidu {
 namespace galaxy {
 namespace cgroups {
-
 bool FreezerSwitch(const std::string& hierarchy,
                    const std::string& cgroup,
                    const std::string& freezer_state) {
@@ -31,6 +30,8 @@ bool FreezerSwitch(const std::string& cgroup,
         if (0 != Write(cgroup, 
                        "freezer.state", 
                        freezer_state)) {
+            LOG(WARNING, "fail to write freeze state %s to %s",
+                    freezer_state.c_str(), cgroup.c_str());
             return false; 
         }     
         ::usleep(100000);  
@@ -38,6 +39,7 @@ bool FreezerSwitch(const std::string& cgroup,
         if (0 != Read(cgroup,
                       "freezer.state",
                       &freezer_state_val)) {
+            LOG(WARNING, "fail to read freeze state from %s", cgroup.c_str());
             return false; 
         } 
         if (freezer_state_val == freezer_state) {

--- a/src/agent/task_manager.cc
+++ b/src/agent/task_manager.cc
@@ -884,7 +884,6 @@ void TaskManager::DelayCheckTaskStageChange(const std::string& task_id) {
     }
 
     TaskInfo* task_info = it->second;
-    SetResourceUsage(task_info);
     int32_t task_delay_check_time = FLAGS_agent_detect_interval;
     // switch task stage
     if (task_info->stage == kTaskStagePENDING 
@@ -1038,6 +1037,16 @@ bool TaskManager::HandleInitTaskMemCgroup(std::string& subsystem , TaskInfo* tas
                     memory_limit, mem_path.c_str()); 
             return false;
         }
+    }
+	const int GROUP_KILL_MODE = 0;
+    if (file::IsExists(mem_path + "/memory.kill_mode") 
+          && cgroups::Write(mem_path,
+                "memory.kill_mode", 
+                boost::lexical_cast<std::string>(GROUP_KILL_MODE)
+                ) != 0) {
+        LOG(WARNING, "set memory kill mode failed for %s", 
+                mem_path.c_str()); 
+        return false;
     }
     return true; 
 }

--- a/src/agent/task_manager.cc
+++ b/src/agent/task_manager.cc
@@ -279,7 +279,7 @@ int TaskManager::ReloadTask(const TaskInfo& task) {
     } while (0);
     if (task_info->desc.has_mem_isolation_type() && 
         task_info->desc.mem_isolation_type() == kMemIsolationCgroup && FLAGS_agent_use_galaxy_oom_killer){
-        LOG(INFO, "task %s use galaxy memory killer ", task_info->task_id.c_str());
+        LOG(INFO, "task %s use galaxy oom killer ", task_info->task_id.c_str());
         killer_pool_.DelayTask(FLAGS_agent_memory_check_interval,
                           boost::bind(&TaskManager::MemoryCheck, this, task_info->task_id));
     }
@@ -328,7 +328,7 @@ int TaskManager::CreateTask(const TaskInfo& task) {
     if (task_info->desc.has_mem_isolation_type() && 
                task_info->desc.mem_isolation_type() == 
                     kMemIsolationCgroup && FLAGS_agent_use_galaxy_oom_killer){
-        LOG(INFO, "task %s use galaxy memory killer ", task_info->task_id.c_str());
+        LOG(INFO, "task %s use galaxy oom killer ", task_info->task_id.c_str());
         killer_pool_.DelayTask(FLAGS_agent_memory_check_interval,
                           boost::bind(&TaskManager::MemoryCheck, this, task_info->task_id));
     }
@@ -1188,9 +1188,6 @@ void TaskManager::MemoryCheck(const std::string& task_id) {
     }
     TaskInfo* task = it->second;
     SetResourceUsage(task);
-    LOG(INFO, "[galaxy memory monitor] task %s mem used %ld mem limit %ld", task_id.c_str(), 
-        task->status.resource_used().memory(),
-        task->desc.requirement().memory());
     if (task->status.resource_used().memory()+ GALAXY_OOM_KILLER_OFFSET >= task->desc.requirement().memory()) {
         bool ok = KillTask(task);
         LOG(INFO, "[galaxy killer] task %s of pod %s of job %s is oom and kill it with ret %d",

--- a/src/agent/task_manager.cc
+++ b/src/agent/task_manager.cc
@@ -1143,7 +1143,7 @@ bool TaskManager::KillTask(TaskInfo* task) {
         std::vector<int>::iterator pid_it = pids.begin();
         for (; pid_it != pids.end(); ++pid_it) {
             int pid = *pid_it;
-            if (pid != 0) {
+            if (pid > 1) {
                 ::kill(pid, SIGKILL); 
             }
         }

--- a/src/agent/task_manager.h
+++ b/src/agent/task_manager.h
@@ -77,10 +77,15 @@ protected:
     bool HandleInitTaskComCgroup(std::string& subsystem, TaskInfo* task);
     bool HandleInitTaskTcpCgroup(std::string& subsystem, TaskInfo* task);
     int InitTcpthrotEnv();
+
+    bool KillTask(TaskInfo* task);
+
+    void MemoryCheck(const std::string& task_id);
 protected:
     Mutex tasks_mutex_;
     std::map<std::string, TaskInfo*> tasks_;
     ThreadPool background_thread_;
+    ThreadPool killer_pool_;
     std::string cgroup_root_;
     typedef boost::function<bool (TaskInfo* task)> CgroupFunc;
     std::map<std::string, CgroupFunc> cgroup_funcs_;

--- a/src/flags.cc
+++ b/src/flags.cc
@@ -73,6 +73,7 @@ DEFINE_string(agent_global_hardlimit_path, "galaxy", "agent cpu hard limit root"
 DEFINE_string(agent_global_softlimit_path, "softlimit", "agent cpu soft limit root");
 DEFINE_string(agent_global_cgroup_path, "galaxy", "agent cgroup global path");
 DEFINE_int32(agent_detect_interval, 1000, "agent detect process running interval");
+DEFINE_int32(agent_memory_check_interval, 200, "agent check task memory interval");
 DEFINE_int32(agent_task_oom_delay_restart_time, 30000, "agent task oom delay restart time");
 DEFINE_string(agent_default_user, "galaxy", "agent default run task user");
 DEFINE_int32(send_bps_quota, 200000000, "galaxy net send limit");

--- a/src/flags.cc
+++ b/src/flags.cc
@@ -74,7 +74,7 @@ DEFINE_string(agent_global_softlimit_path, "softlimit", "agent cpu soft limit ro
 DEFINE_string(agent_global_cgroup_path, "galaxy", "agent cgroup global path");
 DEFINE_int32(agent_detect_interval, 1000, "agent detect process running interval");
 DEFINE_int32(agent_memory_check_interval, 200, "agent check task memory interval");
-DEFINE_int32(agent_task_oom_delay_restart_time, 30000, "agent task oom delay restart time");
+DEFINE_bool(agent_use_galaxy_oom_killer, false, "use galaxy oom killer default false, use cgroup oom killer");
 DEFINE_string(agent_default_user, "galaxy", "agent default run task user");
 DEFINE_int32(send_bps_quota, 200000000, "galaxy net send limit");
 DEFINE_int32(recv_bps_quota, 200000000, "galaxy new recv limit");

--- a/src/proto/galaxy.proto
+++ b/src/proto/galaxy.proto
@@ -73,8 +73,14 @@ message Resource {
 }
 
 enum MemIsolationType {
+    // cgroup
     kMemIsolationCgroup = 0;
+    // user custom limit
     kMemIsolationLimit = 1;
+    // ulimit
+    kMemIsolationUlimit = 2;
+    // galaxy limit
+    kMemIsolationGlimit = 3;
 }
 
 enum CpuIsolationType {

--- a/src/proto/galaxy.proto
+++ b/src/proto/galaxy.proto
@@ -77,10 +77,6 @@ enum MemIsolationType {
     kMemIsolationCgroup = 0;
     // user custom limit
     kMemIsolationLimit = 1;
-    // ulimit
-    kMemIsolationUlimit = 2;
-    // galaxy limit
-    kMemIsolationGlimit = 3;
 }
 
 enum CpuIsolationType {


### PR DESCRIPTION
galaxy 在创建task时，会多给任务加50M内存，以便在不触发cgroup oom前让galaxy killer把 task  kill 掉。
galaxy agent会 200毫秒检查一下任务使用内存（rss + page cache）,采集还是使用 cgroup里面的memory.stat， 如果内存使用mem_used + 50m >= 任务设置的limit 会触发galaxy killer ,然后任务重启