### PR TITLE
修复用户stop命令调用多次的bug

### DIFF
--- a/src/agent/task_manager.cc
+++ b/src/agent/task_manager.cc
@@ -555,11 +555,12 @@ int TaskManager::TerminateTask(TaskInfo* task_info) {
     if (task_info == NULL) {
         return -1; 
     }
-    std::string stop_command = task_info->desc.stop_command();
-    task_info->stage = kTaskStageSTOPPING;
-    SetupTerminateProcessKey(task_info);
 
     if (0 ==  task_info->stop_timeout_point) {
+        std::string stop_command = task_info->desc.stop_command();
+        task_info->stage = kTaskStageSTOPPING;
+        SetupTerminateProcessKey(task_info);
+
         // send rpc to initd to execute stop process
         ExecuteRequest initd_request; 
         ExecuteResponse initd_response;


### PR DESCRIPTION
修复用户stop命令调用多次的bug
当进程被D住后， galaxy-agent 无法kill掉task， galaxy-master会不停地下发kill命令， 
galaxy-agent接收kill命令后会调用TermiateTask函数， 进而会多次调用用户的stop命令