### PR TITLE
cancel cpu.cfs_quota_us for cpu-softlimit-task

### DIFF
--- a/src/agent/task_manager.h
+++ b/src/agent/task_manager.h
@@ -72,7 +72,6 @@ protected:
                                         + "_stop"); 
     }
     bool InitCpuSubSystem();
-    bool HandleHardlimitChange(int32_t hardlimit_cores);
     bool HandleInitTaskCpuCgroup(std::string& subsystem, TaskInfo* task);
     bool HandleInitTaskMemCgroup(std::string& subsystem, TaskInfo* task);
     bool HandleInitTaskComCgroup(std::string& subsystem, TaskInfo* task);

--- a/src/flags.cc
+++ b/src/flags.cc
@@ -72,10 +72,7 @@ DEFINE_int32(agent_rpc_initd_timeout, 2, "agent monitor initd interval, unit sec
 DEFINE_int32(agent_initd_port_begin, 9000, "agent initd port used begin");
 DEFINE_int32(agent_initd_port_end, 9500, "agent initd port used end");
 DEFINE_string(agent_persistence_path, "./data", "agent persistence path");
-// hard limit
-DEFINE_string(agent_global_hardlimit_path, "galaxy", "agent cpu hard limit root");
-// soft limit
-DEFINE_string(agent_global_softlimit_path, "softlimit", "agent cpu soft limit root");
+
 DEFINE_string(agent_global_cgroup_path, "galaxy", "agent cgroup global path");
 DEFINE_int32(agent_detect_interval, 1000, "agent detect process running interval");
 DEFINE_int32(agent_io_collect_interval, 1000, "agent collect io interval");

--- a/src/master/job_manager.cc
+++ b/src/master/job_manager.cc
@@ -363,6 +363,10 @@ void JobManager::FillPodsToJob(Job* job) {
     LOG(INFO, "pod namespace_isolation is: [%d]", job->desc_.pod().namespace_isolation());
     for(int i = pods_size; i < job->desc_.replica(); i++) {
         PodId pod_id = MasterUtil::UUID();
+        if (job->desc_.has_name()) {
+            pod_id = MasterUtil::ShortName(job->desc_.name()) + "_" + pod_id;
+        }
+
         PodStatus* pod_status = new PodStatus();
         pod_status->set_podid(pod_id);
         pod_status->set_jobid(job->id_);

--- a/src/master/master_impl.cc
+++ b/src/master/master_impl.cc
@@ -171,6 +171,11 @@ void MasterImpl::SubmitJob(::google::protobuf::RpcController* /*controller*/,
     const JobDescriptor& job_desc = request->job();
     MasterUtil::TraceJobDesc(job_desc);
     JobId job_id = MasterUtil::UUID();
+
+    if (job_desc.has_name()) {
+        job_id = MasterUtil::ShortName(job_desc.name()) + "_" + job_id;
+    }
+
     Status status = job_manager_.Add(job_id, job_desc);
     response->set_status(status);
     if (status == kOk) {

--- a/src/master/master_util.cc
+++ b/src/master/master_util.cc
@@ -8,6 +8,7 @@
 #include <sys/utsname.h>
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
+#include <boost/algorithm/string/replace.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/lexical_cast.hpp>
 #include <gflags/gflags.h>
@@ -156,6 +157,11 @@ void MasterUtil::ResetLabels(AgentInfo* agent,
         agent->add_tags(*it); 
     }
     return;
+}
+
+std::string MasterUtil::ShortName(const std::string& job_name) {
+    std::string name = boost::replace_all_copy(job_name, " ", "-");
+    return name.substr(0, 20);
 }
 
 }

--- a/src/master/master_util.h
+++ b/src/master/master_util.h
@@ -30,6 +30,7 @@ public:
                         std::set<std::string>* right_diff);
     static void ResetLabels(AgentInfo* agent, const std::set<std::string>& labels);
     static std::string UUID();
+    static std::string ShortName(const std::string& job_name);
 };
 
 }   


### PR DESCRIPTION
cpu 采用cgroup嵌套的格式方式存在不稳定因素，
取消cpu嵌套方式